### PR TITLE
Add batch functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ If present, will set the time of exit. If not present, will use the default time
 
 `-d dd-mm-yyyy` or `--date dd-mm-yyyy`
 
-If present, will set the date of the records. If not present, will use today's date.
+If present, will set the initial date of the records. If not present, will use today's date.
+
+`-f dd-mm-yyyy` or `--final dd-mm-yyyy`
+
+If present, will set the final of the records. If not present, will use today's date.
+
+If the dates from `-d` and `-f` are different, will iterate through all weekdays in between and record them. If both are empty, then just set the marks for the current day.
 
 `-u [USERNAME]` or `--user [USERNAME]`
 
@@ -50,6 +56,13 @@ Will set the password to `[PASSWORD]`. If not present, uses the value of the env
 `$ ./idontime -i 08:00 --out 17:00 --date 18-01-2021 --headless`
 
 Will run the script in headless mode, and create a set of entries for the date 18-01-2021, starting at 8am, ending at 5pm.
+
+The username and password will be fetched from environment variables.
+
+
+`$ ./idontime -i 08:00 --out 17:00 --date 10-01-2021 --final 16-01-2021 --headless`
+
+Will run the script in headless mode, and create a set of entries for the weekdays between 10-01-2021 and 16-01-2021 (11-01-2021 to 15-01-2021), starting at 8am, ending at 5pm.
 
 The username and password will be fetched from environment variables.
 

--- a/idontime
+++ b/idontime
@@ -27,6 +27,10 @@ option_parser = OptionParser.new do |opts|
     options[:date] = date
   end
 
+  opts.on('-f DATE', '--final DATE', /^\d{2}-\d{2}-\d{4}$/) do |date|
+    options[:final] = date
+  end
+
   opts.on('-u USER', '--user USER') do |user|
     options[:user] = user
   end
@@ -41,6 +45,7 @@ driver = create_driver(options.key?(:headless))
 time_in = options.key?(:time_in) ? options[:time_in] : options[:default_time_in]
 time_out = options.key?(:time_out) ? options[:time_out] : options[:default_time_out]
 date = options.key?(:date) ? options[:date] : Time.now.strftime('%d-%m-%Y')
+final = options.key?(:final) ? options[:final] : Time.now.strftime('%d-%m-%Y')
 user = options.key?(:user) ? options[:user] : ENV['IDONTIME_USER']
 password = options.key?(:password) ? options[:password] : ENV['IDONTIME_PASSWORD']
 
@@ -49,8 +54,13 @@ rescue_exceptions do
   find_by_id_and_fill_in(driver, options[:user_field], user)
   find_by_id_and_fill_in(driver, options[:password_field], password)
   click(driver, options[:login_button])
-  create_entry(driver, date, time_in, options[:entry_in], options)
-  create_entry(driver, date, time_out, options[:entry_out], options)
+  Date.parse(date).upto(Date.parse(final)) { |entry|
+    fmt_entry = entry.strftime('%d-%m-%Y')
+    unless entry.saturday? || entry.sunday? 
+    create_entry(driver, fmt_entry, time_in, options[:entry_in], options)
+    create_entry(driver, fmt_entry, time_out, options[:entry_out], options)
+    end
+  }
 end
 
 driver.quit


### PR DESCRIPTION
# What?
Adding batch functionality

# Why?
It would be interesting to be able to input entries in batch, like picking the weekdays on a range of dates, so that you dont need to do it everyday by yourself.

We have tested it with 2 different accounts, with various ranges (with weekends in between) and everything seems to be working fine.

If running without placing dates at all, then we reproduce the current behaviour.